### PR TITLE
feat: add remove_keys method to base

### DIFF
--- a/mongospecs/base.py
+++ b/mongospecs/base.py
@@ -687,6 +687,33 @@ class SpecBase(t.Generic[SpecDocumentType]):
                     child_document = child_document[key]
                 child_document[keys[-1]] = value
 
+    @classmethod
+    def _remove_keys(cls, parent_dict: dict[str, t.Any], paths: list[str]):
+        """
+        Remove a list of keys from a dictionary.
+
+        Keys are specified as a series of `.` separated paths for keys in child
+        dictionaries, e.g 'parent_key.child_key.grandchild_key'.
+        """
+
+        for path in paths:
+            keys = cls._path_to_keys(path)
+
+            # Traverse to the tip of the path
+            child_dict = parent_dict
+            for key in keys[:-1]:
+                child_dict = child_dict.get(key)
+
+                if child_dict is None:
+                    break
+
+            if child_dict is None:
+                continue
+
+            # Remove the key
+            if keys[-1] in child_dict:
+                child_dict.pop(keys[-1])
+
     # Signals
     @classmethod
     def listen(cls, event: str, func: t.Callable[..., t.Any]) -> None:

--- a/mongospecs/base.py
+++ b/mongospecs/base.py
@@ -702,17 +702,15 @@ class SpecBase(t.Generic[SpecDocumentType]):
             # Traverse to the tip of the path
             child_dict = parent_dict
             for key in keys[:-1]:
-                child_dict = child_dict.get(key)
+                child_dict = child_dict.get(key, {})
 
-                if child_dict is None:
-                    break
+                if not isinstance(child_dict, dict):
+                    continue
 
-            if child_dict is None:
+            if not isinstance(child_dict, dict):
                 continue
 
-            # Remove the key
-            if keys[-1] in child_dict:
-                child_dict.pop(keys[-1])
+            child_dict.pop(keys[-1], None)
 
     # Signals
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mongospecs"
-version = "0.1.1"
+version = "0.1.2"
 description = "simple mongo ODM with support for msgspec, pydantic, and attrs"
 authors = ["Jay <jay.github0@gmail.com>"]
 repository = "https://github.com/jaykv/mongospecs"

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,37 @@
+import pytest
+
+from mongospecs.base import SpecBase
+
+
+@pytest.mark.parametrize(
+    "parent_dict, paths, expected_result",
+    [
+        # Happy path tests
+        ({"a": "something"}, ["a"], {}),  # Remove only key
+        ({"a": 1, "b": {"c": 2}}, ["b.c"], {"a": 1, "b": {}}),  # Remove nested key
+        ({"a": 1, "b": {"c": 2}}, ["a"], {"b": {"c": 2}}),  # Remove top-level key
+        ({"a": {"b": {"c": 3}}}, ["a.b.c"], {"a": {"b": {}}}),  # Deeply nested key
+        # Edge cases
+        ({}, ["a"], {}),  # Empty dictionary
+        ({"a": 1}, [], {"a": 1}),  # No paths to remove
+        ({"a": {"b": {"c": 3}}}, ["a.b.d"], {"a": {"b": {"c": 3}}}),  # Non-existent key
+        # Error cases
+        ({"a": 1}, ["b.c"], {"a": 1}),  # Non-existent nested path
+        ({"a": {"b": 2}}, ["a.b.c"], {"a": {"b": 2}}),  # Non-existent deeper path
+    ],
+    ids=[
+        "remove_only_key",
+        "remove_nested_key",
+        "remove_top_level_key",
+        "deeply_nested_key",
+        "empty_dict",
+        "no_paths",
+        "non_existent_key",
+        "non_existent_nested_path",
+        "non_existent_deeper_path",
+    ],
+)
+def test_remove_keys(parent_dict, paths, expected_result):
+    SpecBase._remove_keys(parent_dict, paths)
+
+    assert parent_dict == expected_result


### PR DESCRIPTION
## Summary by Sourcery

Add the _remove_keys method to the base class to enable key removal from dictionaries using dot-separated paths, and update the project version to 0.1.2.

New Features:
- Introduce the _remove_keys method to the base class, allowing removal of specified keys from a dictionary using dot-separated paths.

Build:
- Update the project version from 0.1.1 to 0.1.2 in pyproject.toml.